### PR TITLE
Some fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ zookeeper_url: http://www.us.apache.org/dist/zookeeper/zookeeper-{{zookeeper_ver
 
 apt_cache_timeout: 3600
 client_port: 2181
+zookeeper_leader_port: "2888"
+zookeeper_election_port: "3888"
 init_limit: 5
 sync_limit: 2
 tick_time: 2000

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,27 +1,45 @@
 ---
 - name: Update apt cache
   apt: update_cache=yes cache_valid_time={{apt_cache_timeout}}
-  tags: bootstrap
+  tags: ['bootstrap']
 
 - name: Apt install required system packages.
   apt: pkg={{item}} state=installed
-  tags: bootstrap
+  tags: ['bootstrap']
   with_items:
     - zookeeper
     - zookeeperd
 
-- name: Overwrite myid file.
+- name: Clean Zookeeper configuration
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+    - /run/systemd/generator.late/zookeeper.service
+  tags: ['bootstrap', 'deploy']
+
+- name: Write zookeeper.service file
+  template: src=zookeeper.service.j2 dest=/lib/systemd/system/zookeeper.service
+  tags: ['bootstrap', 'deploy']
+
+- name: Overwrite myid file
   template: src=myid.j2 dest=/etc/zookeeper/conf/myid
-  tags: deploy
-  notify:
-    - Restart zookeeper
+  tags: ['bootstrap', 'deploy']
 
 - name: Overwrite default config file
   template: src=zoo.cfg.j2 dest=/etc/zookeeper/conf/zoo.cfg
-  tags: deploy
-  notify:
-    - Restart zookeeper
+  tags: ['bootstrap', 'deploy']
 
-- name: Start zookeeper service
-  service: name=zookeeper state=started enabled=yes
-  tags: deploy
+- name: Enable zookeeper service
+  become: yes
+  command: systemctl enable zookeeper
+  when: ansible_service_mgr == 'systemd'
+  tags: ['deploy']
+
+- name: Start ZooKeeper
+  systemd:
+    name: zookeeper
+    state: restarted
+    daemon_reload: yes
+    enabled: yes
+  tags: ['deploy']

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -41,13 +41,9 @@
   notify:
     - Restart zookeeper
 
-- name: Check if systemd exists
-  stat: path=/usr/lib/systemd/system/
-  register: systemd_check
-
 - name: Systemd script.
   template: src=zookeeper.service.j2 dest=/usr/lib/systemd/system/zookeeper.service
-  when: systemd_check.stat.exists == true
+  when: ansible_service_mgr == 'systemd'
   tags: deploy
   notify:
     - Restart zookeeper

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -29,7 +29,7 @@ server.{{server.id}}={{server.host}}:2888:3888
 #}
 
 {% for server in zookeeper_hosts %}
-server.{{loop.index}}={{server.host}}:2888:3888
+server.{{loop.index}}={{server.host}}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -2,14 +2,26 @@
 
 [Unit]
 Description=ZooKeeper
+{# LSC: Can't use the following, as it will fail to restart the downstream
+ # services in case of failure and proper restart of the upstream services.
+ #}
+#BindsTo=network.target
+
+Requires=network.target
+After=network.target
+
+{# LSC: Make sure that we are restarted if our upstream dependencies are
+ # restarted.
+ #}
+PartOf=mesos-master.service zookeeper.service network.target
 
 [Service]
 Type=simple
 User=zookeeper
 Group=zookeeper
 ExecStart={{zookeeper_dir}}/bin/zkServer.sh start-foreground
-
-TimeoutSec=300
+Restart=on-failure
+TimeoutSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Two commits:
1. Automatic restarts fo the service:
   - make sure ZooKeeper is enabled => so it is started upon host reboots
   - make sure ZooKeeper is automatically restarted upon failure (but not on successful shutdowns)
2. Small enhancement:
   - Allow election leader / follower ports to be customised